### PR TITLE
Fix typo in table of contents

### DIFF
--- a/process/process-vocabulary.md
+++ b/process/process-vocabulary.md
@@ -20,7 +20,7 @@
 
 [4 Build script for a human readable List of Terms document](#4-build-script-for-a-human-readable-list-of-terms-document)
 
-[5 Generating JSON-LS for controlled vocabularies](#5-generating-json-ld-for-controlled-vocabularies)
+[5 Generating JSON-LD for controlled vocabularies](#5-generating-json-ld-for-controlled-vocabularies)
 
 [6 Reference](#6-reference)
 


### PR DESCRIPTION
Table of contents has `JSON-LS` instead of `JSON-LD`